### PR TITLE
Change the behavior of `run_all_pending_jobs` to wait for jobs to begin running

### DIFF
--- a/integration_tests/tests/test_guard.rs
+++ b/integration_tests/tests/test_guard.rs
@@ -33,7 +33,7 @@ impl<'a, Env> TestGuard<'a, Env> {
         let manager = r2d2::ConnectionManager::new(database_url);
         let pool = pool_builder().build_unchecked(manager);
 
-        let builder = Runner::builder(pool, env).thread_count(2);
+        let builder = Runner::builder(pool, env);
 
         GuardBuilder { builder }
     }

--- a/swirl/src/db.rs
+++ b/swirl/src/db.rs
@@ -2,19 +2,26 @@ use diesel::PgConnection;
 use std::error::Error;
 use std::ops::Deref;
 
+pub type DieselPooledConn<'a, T> = <T as BorrowedConnection<'a>>::Connection;
+
+/// A trait to work around associated type constructors
+///
+/// This will eventually change to `type Connection<'a>` on [`DieselPool`]
+pub trait BorrowedConnection<'a> {
+    /// The smart pointer returned by this connection pool.
+    type Connection: Deref<Target = PgConnection>;
+}
+
 /// A connection pool for Diesel database connections
 ///
 /// If you don't care about the details of connection pooling, or want to use
 /// the r2d2 crate, you can enable the r2d2 feature on this crate and never
 /// be concerned with this trait. If you want to use your own connection pool,
 /// you can implement this trait manually.
-pub trait DieselPool<'a>: Clone + Send {
-    /// The smart pointer returned by this connection pool.
-    type Connection: Deref<Target = PgConnection>;
-
+pub trait DieselPool: Clone + Send + for<'a> BorrowedConnection<'a> {
     /// The error type returned when a connection could not be retreived from
     /// the pool.
-    type Error: Error + 'static;
+    type Error: Error + Send + 'static;
 
     /// Attempt to get a database connection from the pool. Errors if a
     /// connection could not be retrieved from the pool.
@@ -24,12 +31,8 @@ pub trait DieselPool<'a>: Clone + Send {
     ///
     /// - A timeout was reached
     /// - An error occurred establishing a new connection
-    fn get(&'a self) -> Result<Self::Connection, Self::Error>;
+    fn get<'a>(&'a self) -> Result<DieselPooledConn<'a, Self>, Self::Error>;
 }
-
-/// A helper trait for `for<'a> DieselPool<'a>`
-pub trait DieselPoolOwned: for<'a> DieselPool<'a> {}
-impl<T> DieselPoolOwned for T where for<'a> T: DieselPool<'a> {}
 
 #[cfg(feature = "r2d2")]
 mod r2d2_impl {
@@ -38,11 +41,14 @@ mod r2d2_impl {
 
     type ConnectionManager = r2d2::ConnectionManager<PgConnection>;
 
-    impl<'a> DieselPool<'a> for r2d2::Pool<ConnectionManager> {
+    impl<'a> BorrowedConnection<'a> for r2d2::Pool<ConnectionManager> {
         type Connection = r2d2::PooledConnection<ConnectionManager>;
+    }
+
+    impl DieselPool for r2d2::Pool<ConnectionManager> {
         type Error = r2d2::PoolError;
 
-        fn get(&'a self) -> Result<Self::Connection, Self::Error> {
+        fn get<'a>(&'a self) -> Result<DieselPooledConn<'a, Self>, Self::Error> {
             self.get()
         }
     }

--- a/swirl/src/errors.rs
+++ b/swirl/src/errors.rs
@@ -1,7 +1,71 @@
+use diesel::result::Error as DieselError;
 use std::error::Error;
+use std::fmt;
+
+use crate::db::DieselPool;
 
 /// An error occurred queueing the job
 pub type EnqueueError = Box<dyn Error + Send + Sync>;
 
 /// An error occurred performing the job
 pub type PerformError = Box<dyn Error>;
+
+/// An error occurred while attempting to fetch jobs from the queue
+pub enum FetchError<Pool: DieselPool> {
+    /// We could not acquire a database connection from the pool.
+    ///
+    /// Either the connection pool is too small, or new connections cannot be
+    /// established.
+    NoDatabaseConnection(Pool::Error),
+
+    /// Could not execute the query to load a job from the database.
+    FailedLoadingJob(DieselError),
+
+    /// No message was received from the worker thread.
+    ///
+    /// Either the thread pool is too small, or jobs have hung indefinitely
+    NoMessageReceived,
+}
+
+impl<Pool: DieselPool> fmt::Debug for FetchError<Pool> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            FetchError::NoDatabaseConnection(e) => {
+                f.debug_tuple("NoDatabaseConnection").field(e).finish()
+            }
+            FetchError::FailedLoadingJob(e) => f.debug_tuple("FailedLoadingJob").field(e).finish(),
+            FetchError::NoMessageReceived => f.debug_struct("NoMessageReceived").finish(),
+        }
+    }
+}
+
+impl<Pool: DieselPool> fmt::Display for FetchError<Pool> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            FetchError::NoDatabaseConnection(e) => {
+                write!(f, "Timed out acquiring a database connection. ")?;
+                write!(f, "Try increasing the connection pool size: ")?;
+                write!(f, "{}", e)?;
+            }
+            FetchError::FailedLoadingJob(e) => {
+                write!(f, "An error occurred loading a job from the database: ")?;
+                write!(f, "{}", e)?;
+            }
+            FetchError::NoMessageReceived => {
+                write!(f, "No message was received from the worker thread. ")?;
+                write!(f, "Try increasing the thread pool size or timeout period.")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<Pool: DieselPool> Error for FetchError<Pool> {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            FetchError::NoDatabaseConnection(e) => Some(e),
+            FetchError::FailedLoadingJob(e) => Some(e),
+            FetchError::NoMessageReceived => None,
+        }
+    }
+}

--- a/swirl/src/runner/channel.rs
+++ b/swirl/src/runner/channel.rs
@@ -1,0 +1,32 @@
+//! A wrapper around a `std::sync::mpsc::sync_channel` that allows easy creation
+//! of a dummy sender for tests, and doesn't error if the receiver hung up
+
+pub use std::sync::mpsc::Receiver;
+use std::sync::mpsc::{sync_channel, SyncSender};
+
+pub fn new<T>(size: usize) -> (Sender<T>, Receiver<T>) {
+    let (std_sender, std_receiver) = sync_channel(size);
+    (Sender(std_sender), std_receiver)
+}
+
+#[cfg(test)]
+pub fn dummy_sender<T>() -> Sender<T> {
+    new(1).0
+}
+
+pub struct Sender<T>(SyncSender<T>);
+
+impl<T> Sender<T> {
+    pub fn send(&self, t: T) {
+        let _ = self.0.send(t);
+    }
+}
+
+impl<T> Clone for Sender<T>
+where
+    SyncSender<T>: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}

--- a/swirl/src/runner/event.rs
+++ b/swirl/src/runner/event.rs
@@ -1,0 +1,28 @@
+use diesel::result::Error as DieselError;
+
+use super::channel;
+use crate::db::DieselPool;
+
+pub type EventSender<Pool> = channel::Sender<Event<Pool>>;
+
+pub enum Event<Pool: DieselPool> {
+    Working,
+    NoJobAvailable,
+    ErrorLoadingJob(DieselError),
+    FailedToAcquireConnection(Pool::Error),
+}
+
+use std::fmt;
+
+impl<Pool: DieselPool> fmt::Debug for Event<Pool> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Event::Working => f.debug_struct("Working").finish(),
+            Event::NoJobAvailable => f.debug_struct("NoJobAvailable").finish(),
+            Event::ErrorLoadingJob(e) => f.debug_tuple("ErrorLoadingJob").field(e).finish(),
+            Event::FailedToAcquireConnection(e) => {
+                f.debug_tuple("FailedToAcquireConnection").field(e).finish()
+            }
+        }
+    }
+}

--- a/swirl/src/storage.rs
+++ b/swirl/src/storage.rs
@@ -60,13 +60,6 @@ pub fn failed_job_count(conn: &PgConnection) -> QueryResult<i64> {
         .get_result(conn)
 }
 
-/// The number of jobs available to be run
-pub fn available_job_count(conn: &PgConnection) -> QueryResult<i64> {
-    use crate::schema::background_jobs::dsl::*;
-
-    background_jobs.count().filter(retriable()).get_result(conn)
-}
-
 /// Deletes a job that has successfully completed running
 pub fn delete_successful_job(conn: &PgConnection, job_id: i64) -> QueryResult<()> {
     use crate::schema::background_jobs::dsl::*;


### PR DESCRIPTION
Before this would do a query to see how many jobs could be retried, and
then loop that many times queueing them up, and immediately return. This
was problematic for a few reasons.

- It was hard to test. We needed to do explicit synchronization to make
  sure jobs were actually running (we're still doing that in tests that
  care about locking behavior)
- It never communicated when a catastrophic error has occurred. If the
  thread pool or connection pool become poisoned, we'd never find out.
  We'd just blindly enqueue jobs which would immediately fail
- It didn't determine whether jobs were actually locked or not.
- It required an extra connection in the pool for the count
- The runner never knew if jobs actually started or not. Ultimately if
  jobs aren't running, we want to kill the runner and restart it.

The new system works as follows:

- Create a new channel for the worker threads to communicate with the
  coordinating thread
- Queue as many jobs to run as there are available threads, or 1 if no
  threads are available and we've *never* queued a job
  - We need to queue at least 1 job to make sure we receive a message.
    Workers queued before the call to `run_all_pending_jobs` (e.g. they
    were run by the previous call) won't be able to communicate on our
    channel. We need at least one new worker to be executed so we find
    out if there are more jobs to run
- Listen for messages on our channel. Workers communicate if they got a
  job, there are no jobs left, or if an error occurred loading the job
  - The error cases here are only on *loading* a job, not running it.
    An error means either there's no database connection available, or
    we got an error loading the job from the DB. Both cases mean we
    probably need to restart the runner or change the configuration.
- Loop until we get an error message or a message that no jobs are left

This should ensure that our thread pool remains fully saturated, and
that we're returning any errors that occurred. We technically can't
guarantee that we return all errors, since job a could lock a job, job
b tries to lock a job gets none, reports no jobs left, and then job b
fails during deserialization.

I opted to go with the looser guarantee that errors are returned since
an error happening in deserialization is extermely unlikely, and if we
wait for all messages to be received before returning we are less likely
to keep the worker threads fully saturated.