### PR TITLE
Remove the need to register jobs with the runner

### DIFF
--- a/integration_tests/tests/dummy_jobs.rs
+++ b/integration_tests/tests/dummy_jobs.rs
@@ -20,3 +20,5 @@ impl Job for BarrierJob {
         Ok(())
     }
 }
+
+swirl::register_job!(BarrierJob);

--- a/integration_tests/tests/test_guard.rs
+++ b/integration_tests/tests/test_guard.rs
@@ -5,7 +5,6 @@ use std::sync::{Mutex, MutexGuard};
 use swirl::{Builder, Runner};
 
 use crate::db::*;
-use crate::dummy_jobs::*;
 use crate::sync::Barrier;
 use crate::util::*;
 
@@ -19,7 +18,7 @@ lazy_static::lazy_static! {
     static ref TEST_MUTEX: Mutex<()> = Mutex::new(());
 }
 
-pub struct TestGuard<'a, Env> {
+pub struct TestGuard<'a, Env: 'static> {
     runner: Runner<Env, DieselPool>,
     _lock: MutexGuard<'a, ()>,
 }
@@ -41,11 +40,11 @@ impl<'a, Env> TestGuard<'a, Env> {
 
 impl<'a> TestGuard<'a, Barrier> {
     pub fn barrier_runner(env: Barrier) -> Self {
-        Self::builder(env).register::<BarrierJob>().build()
+        Self::builder(env).build()
     }
 }
 
-pub struct GuardBuilder<Env> {
+pub struct GuardBuilder<Env: 'static> {
     builder: Builder<Env, DieselPool>,
 }
 
@@ -55,11 +54,6 @@ impl<Env> GuardBuilder<Env> {
             _lock: TEST_MUTEX.lock().unwrap(),
             runner: self.builder.build(),
         }
-    }
-
-    pub fn register<T: Job<Environment = Env>>(mut self) -> Self {
-        self.builder = self.builder.register::<T>();
-        self
     }
 }
 

--- a/swirl/Cargo.toml
+++ b/swirl/Cargo.toml
@@ -11,6 +11,7 @@ diesel = { version = "1.0.0", features = ["postgres", "serde_json"] }
 threadpool = "1.7"
 serde_json = "1.0.0"
 serde = "1.0.0"
+inventory = "0.1"
 
 [dev-dependencies]
 dotenv = "0.11"

--- a/swirl/examples/run_100k_jobs.rs
+++ b/swirl/examples/run_100k_jobs.rs
@@ -17,6 +17,8 @@ impl Job for DummyJob {
     }
 }
 
+swirl::register_job!(DummyJob);
+
 fn main() -> Result<(), Box<dyn Error>> {
     let database_url = dotenv::var("DATABASE_URL")?;
     let num_cpus = num_cpus::get();
@@ -26,9 +28,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .build(connection_manager)?;
     println!("Enqueuing 100k jobs");
     enqueue_jobs(&*connection_pool.get()?).unwrap();
-    let runner = Runner::builder(connection_pool, ())
-        .register::<DummyJob>()
-        .build();
+    let runner = Runner::builder(connection_pool, ()).build();
     println!("Running jobs");
     let started = Instant::now();
 

--- a/swirl/src/job.rs
+++ b/swirl/src/job.rs
@@ -9,7 +9,7 @@ pub trait Job: Serialize + DeserializeOwned {
     /// The environment this job is run with. This is a struct you define,
     /// which should encapsulate things like database connection pools, any
     /// configuration, and any other static data or shared resources.
-    type Environment;
+    type Environment: 'static;
 
     /// The key to use for storing this job, and looking it up later.
     ///

--- a/swirl/src/lib.rs
+++ b/swirl/src/lib.rs
@@ -3,6 +3,9 @@
 #[macro_use]
 extern crate diesel;
 
+#[doc(hidden)]
+pub extern crate inventory;
+
 mod db;
 mod job;
 mod registry;
@@ -12,8 +15,11 @@ mod storage;
 pub mod errors;
 pub mod schema;
 
-pub use self::db::DieselPool;
-pub use self::errors::*;
-pub use self::job::*;
-pub use self::registry::Registry;
-pub use self::runner::*;
+pub use db::DieselPool;
+pub use errors::*;
+pub use job::*;
+pub use registry::Registry;
+pub use runner::*;
+
+#[doc(hidden)]
+pub use registry::JobVTable;

--- a/swirl/src/registry.rs
+++ b/swirl/src/registry.rs
@@ -1,46 +1,96 @@
 #![allow(clippy::new_without_default)] // https://github.com/rust-lang/rust-clippy/issues/3632
 
-use serde_json;
+use std::any::{Any, TypeId};
 use std::collections::HashMap;
-use std::panic::RefUnwindSafe;
+use std::marker::PhantomData;
 
 use crate::errors::PerformError;
 use crate::Job;
 
-#[doc(hidden)]
-pub type PerformFn<Env> =
-    Box<dyn Fn(serde_json::Value, &Env) -> Result<(), PerformError> + RefUnwindSafe + Send + Sync>;
-
 #[derive(Default)]
 #[allow(missing_debug_implementations)] // Can't derive debug
-/// A registry of background jobs, used to map job types to concrege perform
+/// A registry of background jobs, used to map job types to concrete perform
 /// functions at runtime.
 pub struct Registry<Env> {
-    job_types: HashMap<&'static str, PerformFn<Env>>,
+    jobs: HashMap<&'static str, JobVTable>,
+    _marker: PhantomData<Env>,
 }
 
-impl<Env> Registry<Env> {
-    /// Create a new, empty registry
-    pub fn new() -> Self {
-        Registry {
-            job_types: Default::default(),
+impl<Env: 'static> Registry<Env> {
+    /// Loads the registry from all invocations of [`register_job!`] for this
+    /// environment type
+    pub fn load() -> Self {
+        let jobs = inventory::iter::<JobVTable>
+            .into_iter()
+            .filter(|vtable| vtable.env_type == TypeId::of::<Env>())
+            .map(|&vtable| (vtable.job_type, vtable))
+            .collect();
+
+        Self {
+            jobs: jobs,
+            _marker: PhantomData,
         }
     }
 
     /// Get the perform function for a given job type
-    pub fn get(&self, job_type: &str) -> Option<&PerformFn<Env>> {
-        self.job_types.get(job_type)
+    pub fn get(&self, job_type: &str) -> Option<PerformJob<Env>> {
+        self.jobs.get(job_type).map(|&vtable| PerformJob {
+            vtable,
+            _marker: PhantomData,
+        })
     }
+}
 
-    /// Register a new background job. This will override any existing
-    /// registries with the same `JOB_TYPE`, if one exists.
-    pub fn register<T: Job<Environment = Env>>(&mut self) {
-        self.job_types.insert(
-            T::JOB_TYPE,
-            Box::new(|data, env| {
-                let data = serde_json::from_value(data)?;
-                T::perform(data, env)
-            }),
-        );
+/// Register a job to be run by swirl. This must be called for any
+/// implementors of [`swirl::Job`]
+#[macro_export]
+macro_rules! register_job {
+    ($job_ty: ty) => {
+        $crate::inventory::submit! {
+            #![crate = swirl]
+            swirl::JobVTable::from_job::<$job_ty>()
+        }
+    };
+}
+
+#[doc(hidden)]
+#[derive(Clone, Copy)]
+pub struct JobVTable {
+    env_type: TypeId,
+    job_type: &'static str,
+    perform: fn(serde_json::Value, &Any) -> Result<(), PerformError>,
+}
+
+inventory::collect!(JobVTable);
+
+impl JobVTable {
+    pub fn from_job<T: Job>() -> Self {
+        Self {
+            env_type: TypeId::of::<T::Environment>(),
+            job_type: T::JOB_TYPE,
+            perform: perform_job::<T>,
+        }
+    }
+}
+
+fn perform_job<T: Job>(data: serde_json::Value, env: &Any) -> Result<(), PerformError> {
+    let environment = env.downcast_ref().ok_or_else::<PerformError, _>(|| {
+        "Incorrect environment type. This should never happen. \
+         Please open an issue at https://github.com/sgrif/swirl/issues/new"
+            .into()
+    })?;
+    let data = serde_json::from_value(data)?;
+    T::perform(data, environment)
+}
+
+pub struct PerformJob<Env> {
+    vtable: JobVTable,
+    _marker: PhantomData<Env>,
+}
+
+impl<Env: 'static> PerformJob<Env> {
+    pub fn perform(&self, data: serde_json::Value, env: &Env) -> Result<(), PerformError> {
+        let perform_fn = self.vtable.perform;
+        perform_fn(data, env)
     }
 }


### PR DESCRIPTION
Instead of requiring that the runner call `.register` for every job it
wants to be able to run (which will result in a runtime error if any
queued job wasn't registered with the runner), we instead require that
jobs be registered when they are defined.

This is an improvement for a few reasons:

- Since a job has to be defined somewhere to be enqueued, it's easier to
  enforce that all defined jobs are registered if registration happens
  at the definition site
- Since `impl Job` is intended to eventually be generated, we can
  eventually get to the point where users never have to care about
  registration at all.
- The API we're leaning towards for generating job impls doesn't give a
  clear place to define a struct name, so we need *some* ergonomic way
  to register the jobs

This uses the `inventory` crate, which uses black magic and linker
attributes to define some functions which are run before main, which
populates a list of all jobs that were registered. When constructing the
registry, we then look for all jobs that have the appropriate env type
(in practice this will be all jobs, except for our test suite), and put
those in our `HashMap`.

Surprisingly, this didn't require any unsafe code. We could make this a
bit faster by passing the env as a `*const ()`, rather than using `&Any`
with a runtime check, but our performance is dominated by IO, so the
extra runtime check to ensure we don't blow up folks computers if a bug
slips in is worth it.