### PR TITLE
Intoduce codegen for background jobs

### DIFF
--- a/integration_tests/tests/codegen.rs
+++ b/integration_tests/tests/codegen.rs
@@ -1,0 +1,45 @@
+use crate::dummy_jobs::*;
+use crate::test_guard::TestGuard;
+use swirl::PerformError;
+
+#[test]
+#[should_panic(expected = "1 jobs failed")]
+fn generated_jobs_serialize_all_arguments_except_first() {
+    #[swirl::background_job]
+    fn check_arg_equal_to_env(env: &String, arg: String) -> Result<(), PerformError> {
+        if env == &arg {
+            Ok(())
+        } else {
+            Err("arg wasn't env!".into())
+        }
+    }
+
+    let runner = TestGuard::runner("a".to_string());
+    let conn = runner.connection_pool().get().unwrap();
+    check_arg_equal_to_env("a".into()).enqueue(&conn).unwrap();
+    check_arg_equal_to_env("b".into()).enqueue(&conn).unwrap();
+
+    runner.run_all_pending_jobs().unwrap();
+    runner.assert_no_failed_jobs().unwrap();
+}
+
+#[test]
+#[should_panic(expected = "1 jobs failed")]
+fn jobs_with_args_but_no_env() {
+    #[swirl::background_job]
+    fn assert_foo(arg: String) -> Result<(), PerformError> {
+        if arg == "foo" {
+            Ok(())
+        } else {
+            Err("arg wasn't foo!".into())
+        }
+    }
+
+    let runner = TestGuard::dummy_runner();
+    let conn = runner.connection_pool().get().unwrap();
+    assert_foo("foo".into()).enqueue(&conn).unwrap();
+    assert_foo("not foo".into()).enqueue(&conn).unwrap();
+
+    runner.run_all_pending_jobs().unwrap();
+    runner.assert_no_failed_jobs().unwrap();
+}

--- a/integration_tests/tests/dummy_jobs.rs
+++ b/integration_tests/tests/dummy_jobs.rs
@@ -1,55 +1,25 @@
 pub use swirl::Job;
 
-use serde::*;
 use swirl::errors::PerformError;
 
 use crate::sync::Barrier;
 
 /// A job which takes a barrier as its environment and calls wait on it before
 /// succeeding
-#[derive(Serialize, Deserialize)]
-pub struct BarrierJob;
-
-impl Job for BarrierJob {
-    type Environment = Barrier;
-
-    const JOB_TYPE: &'static str = "BarrierJob";
-
-    fn perform(self, env: &Self::Environment) -> Result<(), PerformError> {
-        env.wait();
-        Ok(())
-    }
+#[swirl::background_job]
+pub fn barrier_job(env: &Barrier) -> Result<(), PerformError> {
+    env.wait();
+    Ok(())
 }
-
-swirl::register_job!(BarrierJob);
 
 /// A job which always fails
-#[derive(Serialize, Deserialize)]
-pub struct FailureJob;
-
-impl Job for FailureJob {
-    type Environment = ();
-
-    const JOB_TYPE: &'static str = "FailureJob";
-
-    fn perform(self, _: &Self::Environment) -> Result<(), PerformError> {
-        Err("failed".into())
-    }
+#[swirl::background_job]
+pub fn failure_job() -> Result<(), PerformError> {
+    Err("failed".into())
 }
 
-swirl::register_job!(FailureJob);
-#[derive(Serialize, Deserialize)]
+#[swirl::background_job]
 /// A job which panics
-pub struct PanicJob;
-
-impl Job for PanicJob {
-    type Environment = ();
-
-    const JOB_TYPE: &'static str = "PanicJob";
-
-    fn perform(self, _: &Self::Environment) -> Result<(), PerformError> {
-        panic!()
-    }
+pub fn panic_job() -> Result<(), PerformError> {
+    panic!()
 }
-
-swirl::register_job!(PanicJob);

--- a/integration_tests/tests/lib.rs
+++ b/integration_tests/tests/lib.rs
@@ -6,4 +6,5 @@ mod sync;
 mod test_guard;
 mod util;
 
+mod codegen;
 mod runner;

--- a/integration_tests/tests/runner.rs
+++ b/integration_tests/tests/runner.rs
@@ -12,10 +12,10 @@ use crate::test_guard::TestGuard;
 #[test]
 fn run_all_pending_jobs_returns_when_all_jobs_enqueued() {
     let barrier = Barrier::new(3);
-    let runner = TestGuard::barrier_runner(barrier.clone());
+    let runner = TestGuard::runner(barrier.clone());
     let conn = runner.connection_pool().get().unwrap();
-    BarrierJob.enqueue(&conn).unwrap();
-    BarrierJob.enqueue(&conn).unwrap();
+    barrier_job().enqueue(&conn).unwrap();
+    barrier_job().enqueue(&conn).unwrap();
 
     runner.run_all_pending_jobs().unwrap();
 
@@ -36,10 +36,10 @@ fn run_all_pending_jobs_returns_when_all_jobs_enqueued() {
 #[test]
 fn assert_no_failed_jobs_blocks_until_all_queued_jobs_are_finished() {
     let barrier = Barrier::new(3);
-    let runner = TestGuard::barrier_runner(barrier.clone());
+    let runner = TestGuard::runner(barrier.clone());
     let conn = runner.connection_pool().get().unwrap();
-    BarrierJob.enqueue(&conn).unwrap();
-    BarrierJob.enqueue(&conn).unwrap();
+    barrier_job().enqueue(&conn).unwrap();
+    barrier_job().enqueue(&conn).unwrap();
 
     runner.run_all_pending_jobs().unwrap();
 
@@ -66,9 +66,9 @@ fn assert_no_failed_jobs_blocks_until_all_queued_jobs_are_finished() {
 fn assert_no_failed_jobs_panics_if_jobs_failed() {
     let runner = TestGuard::dummy_runner();
     let conn = runner.connection_pool().get().unwrap();
-    FailureJob.enqueue(&conn).unwrap();
-    FailureJob.enqueue(&conn).unwrap();
-    FailureJob.enqueue(&conn).unwrap();
+    failure_job().enqueue(&conn).unwrap();
+    failure_job().enqueue(&conn).unwrap();
+    failure_job().enqueue(&conn).unwrap();
 
     runner.run_all_pending_jobs().unwrap();
     runner.assert_no_failed_jobs().unwrap();
@@ -79,8 +79,8 @@ fn assert_no_failed_jobs_panics_if_jobs_failed() {
 fn panicking_jobs_are_caught_and_treated_as_failures() {
     let runner = TestGuard::dummy_runner();
     let conn = runner.connection_pool().get().unwrap();
-    PanicJob.enqueue(&conn).unwrap();
-    FailureJob.enqueue(&conn).unwrap();
+    panic_job().enqueue(&conn).unwrap();
+    failure_job().enqueue(&conn).unwrap();
 
     runner.run_all_pending_jobs().unwrap();
     runner.assert_no_failed_jobs().unwrap();
@@ -96,8 +96,8 @@ fn run_all_pending_jobs_errs_if_jobs_dont_start_in_timeout() {
         .job_start_timeout(Duration::from_millis(50))
         .build();
     let conn = runner.connection_pool().get().unwrap();
-    BarrierJob.enqueue(&conn).unwrap();
-    BarrierJob.enqueue(&conn).unwrap();
+    barrier_job().enqueue(&conn).unwrap();
+    barrier_job().enqueue(&conn).unwrap();
 
     let run_result = runner.run_all_pending_jobs();
     assert_matches!(run_result, Err(swirl::FetchError::NoMessageReceived));

--- a/integration_tests/tests/test_guard.rs
+++ b/integration_tests/tests/test_guard.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 use swirl::{Builder, Runner};
 
 use crate::db::*;
-use crate::sync::Barrier;
 use crate::util::*;
 
 lazy_static::lazy_static! {
@@ -37,17 +36,15 @@ impl<'a, Env> TestGuard<'a, Env> {
 
         GuardBuilder { builder }
     }
+
+    pub fn runner(env: Env) -> Self {
+        Self::builder(env).build()
+    }
 }
 
 impl<'a> TestGuard<'a, ()> {
     pub fn dummy_runner() -> Self {
         Self::builder(()).build()
-    }
-}
-
-impl<'a> TestGuard<'a, Barrier> {
-    pub fn barrier_runner(env: Barrier) -> Self {
-        Self::builder(env).build()
     }
 }
 

--- a/swirl/Cargo.toml
+++ b/swirl/Cargo.toml
@@ -7,6 +7,7 @@ description = "A simple background processing framework for Diesel and PostgreSQ
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+swirl_proc_macro = { path = "../swirl_proc_macro" }
 diesel = { version = "1.0.0", features = ["postgres", "serde_json"] }
 threadpool = "1.7"
 serde_json = "1.0.0"

--- a/swirl/examples/run_100k_jobs.rs
+++ b/swirl/examples/run_100k_jobs.rs
@@ -1,23 +1,13 @@
 use diesel::prelude::*;
 use diesel::r2d2;
-use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::time::Instant;
 use swirl::*;
 
-#[derive(Serialize, Deserialize)]
-struct DummyJob;
-
-impl Job for DummyJob {
-    type Environment = ();
-    const JOB_TYPE: &'static str = "DummyJob";
-
-    fn perform(self, _: &Self::Environment) -> Result<(), PerformError> {
-        Ok(())
-    }
+#[swirl::background_job]
+fn dummy_job() -> Result<(), PerformError> {
+    Ok(())
 }
-
-swirl::register_job!(DummyJob);
 
 fn main() -> Result<(), Box<dyn Error>> {
     let database_url = dotenv::var("DATABASE_URL")?;
@@ -45,7 +35,7 @@ fn enqueue_jobs(conn: &PgConnection) -> Result<(), EnqueueError> {
     use diesel::sql_query;
     sql_query("TRUNCATE TABLE background_jobs;").execute(conn)?;
     for _ in 0..100_000 {
-        DummyJob.enqueue(conn)?;
+        dummy_job().enqueue(conn)?;
     }
     Ok(())
 }

--- a/swirl/src/lib.rs
+++ b/swirl/src/lib.rs
@@ -15,6 +15,8 @@ mod storage;
 pub mod errors;
 pub mod schema;
 
+pub use swirl_proc_macro::*;
+
 pub use db::DieselPool;
 pub use errors::*;
 pub use job::*;

--- a/swirl_proc_macro/Cargo.toml
+++ b/swirl_proc_macro/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "swirl_proc_macro"
+version = "0.1.0"
+authors = ["Sean Griffin <sean@seantheprogrammer.com>"]
+description = "This library should not be used directly, it is re-exported through swirl"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+
+[dependencies]
+syn = { version = "0.15.0", features = ["full", "extra-traits"] }
+quote = "0.6.0"
+proc-macro2 = "0.4.27"
+
+[lib]
+proc-macro = true
+
+[features]
+nightly = ["proc-macro2/nightly"]

--- a/swirl_proc_macro/src/background_job.rs
+++ b/swirl_proc_macro/src/background_job.rs
@@ -1,0 +1,209 @@
+#![warn(warnings)]
+use crate::diagnostic_shim::*;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+
+pub fn expand(item: syn::ItemFn) -> Result<TokenStream, Diagnostic> {
+    let job = BackgroundJob::try_from(item)?;
+
+    let attrs = job.attrs;
+    let vis = job.visibility;
+    let fn_token = job.fn_token;
+    let name = job.name;
+    let env_type = &job.args.env_type;
+    let fn_args = &job.args;
+    let struct_def = job.args.struct_def();
+    let struct_assign = job.args.struct_assign();
+    let arg_names = job.args.names();
+    let return_type = job.return_type;
+    let body = job.body;
+
+    let res = quote! {
+        #(#attrs)*
+        #vis #fn_token #name (#(#fn_args),*) -> #name :: Job {
+            #name :: Job {
+                #(#struct_assign),*
+            }
+        }
+
+        mod #name {
+            use super::*;
+
+            #[derive(serde::Serialize, serde::Deserialize)]
+            pub struct Job {
+                #(#struct_def),*
+            }
+
+            impl swirl::Job for Job {
+                type Environment = #env_type;
+                const JOB_TYPE: &'static str = stringify!(#name);
+
+                #fn_token perform(self, env: &Self::Environment) #return_type {
+                    let Job { #(#arg_names),* } = self;
+                    #(#body)*
+                }
+            }
+
+            swirl::register_job!(Job);
+        }
+    };
+    Ok(res)
+}
+
+struct BackgroundJob {
+    attrs: Vec<syn::Attribute>,
+    visibility: syn::Visibility,
+    fn_token: syn::Token![fn],
+    name: syn::Ident,
+    args: JobArgs,
+    return_type: syn::ReturnType,
+    body: Vec<syn::Stmt>,
+}
+
+impl BackgroundJob {
+    fn try_from(item: syn::ItemFn) -> Result<Self, Diagnostic> {
+        let syn::ItemFn {
+            attrs,
+            vis,
+            constness,
+            unsafety,
+            asyncness,
+            abi,
+            ident,
+            decl,
+            block,
+        } = item;
+
+        if let Some(constness) = constness {
+            return Err(constness
+                .span
+                .error("#[swirl::background_job] cannot be used on const functions"));
+        }
+
+        if let Some(unsafety) = unsafety {
+            return Err(unsafety
+                .span
+                .error("#[swirl::background_job] cannot be used on unsafe functions"));
+        }
+
+        if let Some(asyncness) = asyncness {
+            return Err(asyncness
+                .span
+                .error("#[swirl::background_job] cannot be used on async functions"));
+        }
+
+        if let Some(abi) = abi {
+            return Err(abi
+                .span()
+                .error("#[swirl::background_job] cannot be used on functions with an abi"));
+        }
+
+        if !decl.generics.params.is_empty() {
+            return Err(decl
+                .generics
+                .span()
+                .error("#[swirl::background_job] cannot be used on generic functions"));
+        }
+
+        if let Some(where_clause) = decl.generics.where_clause {
+            return Err(where_clause
+                .where_token
+                .span
+                .error("#[swirl::background_job] cannot be used on functions with a where clause"));
+        }
+
+        let fn_token = decl.fn_token;
+        let return_type = decl.output.clone();
+        let job_args = JobArgs::try_from(*decl)?;
+
+        Ok(Self {
+            attrs,
+            visibility: vis,
+            fn_token,
+            name: ident,
+            args: job_args,
+            return_type,
+            body: block.stmts,
+        })
+    }
+}
+
+struct JobArgs {
+    env_type: syn::Type,
+    args: Punctuated<syn::ArgCaptured, syn::Token![,]>,
+}
+
+impl JobArgs {
+    fn try_from(decl: syn::FnDecl) -> Result<Self, Diagnostic> {
+        let mut first_arg = true;
+        let mut env_type = syn::parse_quote!(());
+        let mut args = Punctuated::new();
+
+        for fn_arg in decl.inputs {
+            let arg_captured = match fn_arg {
+                syn::FnArg::SelfRef(_) | syn::FnArg::SelfValue(_) => {
+                    return Err(fn_arg.span().error("Background jobs cannot take self"));
+                }
+                syn::FnArg::Inferred(_) | syn::FnArg::Ignored(_) => {
+                    unreachable!("would have failed parsing")
+                }
+                syn::FnArg::Captured(arg_captured) => arg_captured,
+            };
+
+            if let syn::Pat::Ident(syn::PatIdent {
+                by_ref: None,
+                subpat: None,
+                ..
+            }) = arg_captured.pat
+            {
+                // ok
+            } else {
+                return Err(arg_captured
+                    .pat
+                    .span()
+                    .error("#[swirl::background_job] cannot yet handle patterns"));
+            }
+
+            if first_arg {
+                first_arg = false;
+                if let syn::Type::Reference(type_ref) = arg_captured.ty {
+                    if let Some(mutable) = type_ref.mutability {
+                        return Err(mutable.span.error("Unexpected `mut`"));
+                    }
+                    env_type = *type_ref.elem;
+                    continue;
+                }
+            }
+
+            args.push(arg_captured);
+        }
+
+        Ok(Self { env_type, args })
+    }
+
+    fn struct_def(&self) -> impl Iterator<Item = proc_macro2::TokenStream> + '_ {
+        self.args.iter().map(|arg| quote::quote!(pub(super) #arg))
+    }
+
+    fn struct_assign(&self) -> impl Iterator<Item = syn::FieldValue> + '_ {
+        self.names().map(|ident| syn::parse_quote!(#ident: #ident))
+    }
+
+    fn names(&self) -> impl Iterator<Item = syn::Ident> + '_ {
+        self.args.iter().map(|arg| match &arg.pat {
+            syn::Pat::Ident(pat_ident) => pat_ident.ident.clone(),
+            _ => unreachable!(),
+        })
+    }
+}
+
+impl<'a> IntoIterator for &'a JobArgs {
+    type Item = <&'a Punctuated<syn::ArgCaptured, syn::Token![,]> as IntoIterator>::Item;
+    type IntoIter = <&'a Punctuated<syn::ArgCaptured, syn::Token![,]> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        (&self.args).into_iter()
+    }
+}

--- a/swirl_proc_macro/src/diagnostic_shim.rs
+++ b/swirl_proc_macro/src/diagnostic_shim.rs
@@ -1,0 +1,57 @@
+use proc_macro2::{Span, TokenStream};
+
+pub trait DiagnosticShim {
+    fn error<T: Into<String>>(self, msg: T) -> Diagnostic;
+}
+
+#[cfg(feature = "nightly")]
+impl DiagnosticShim for Span {
+    fn error<T: Into<String>>(self, msg: T) -> Diagnostic {
+        self.unstable().error(self, msg)
+    }
+}
+
+#[cfg(not(feature = "nightly"))]
+impl DiagnosticShim for Span {
+    fn error<T: Into<String>>(self, msg: T) -> Diagnostic {
+        Diagnostic::error(self, msg)
+    }
+}
+
+#[cfg(feature = "nightly")]
+pub use proc_macro::Diagnostic;
+
+#[cfg(not(feature = "nightly"))]
+pub struct Diagnostic {
+    span: Span,
+    message: String,
+}
+
+#[cfg(not(feature = "nightly"))]
+impl Diagnostic {
+    fn error<T: Into<String>>(span: Span, msg: T) -> Self {
+        Diagnostic {
+            span,
+            message: msg.into(),
+        }
+    }
+}
+
+pub trait DiagnosticExt {
+    fn to_compile_error(self) -> TokenStream;
+}
+
+#[cfg(feature = "nightly")]
+impl DiagnosticExt for Diagnostic {
+    fn to_compile_error(self) -> TokenStream {
+        self.emit();
+        "".parse().unwrap()
+    }
+}
+
+#[cfg(not(feature = "nightly"))]
+impl DiagnosticExt for Diagnostic {
+    fn to_compile_error(self) -> TokenStream {
+        syn::Error::new(self.span, self.message).to_compile_error()
+    }
+}

--- a/swirl_proc_macro/src/lib.rs
+++ b/swirl_proc_macro/src/lib.rs
@@ -1,0 +1,34 @@
+#![deny(warnings)]
+#![recursion_limit = "128"]
+
+extern crate proc_macro;
+
+mod background_job;
+mod diagnostic_shim;
+
+use proc_macro::TokenStream;
+use proc_macro2::Span;
+use syn::{parse_macro_input, ItemFn};
+
+use diagnostic_shim::*;
+
+#[proc_macro_attribute]
+pub fn background_job(attr: TokenStream, item: TokenStream) -> TokenStream {
+    if !attr.is_empty() {
+        return syn::Error::new(
+            Span::call_site(),
+            "swirl::background_job does not take arguments",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let item = parse_macro_input!(item as ItemFn);
+    emit_errors(background_job::expand(item))
+}
+
+fn emit_errors(result: Result<proc_macro2::TokenStream, Diagnostic>) -> TokenStream {
+    result
+        .map(Into::into)
+        .unwrap_or_else(|e| e.to_compile_error().into())
+}


### PR DESCRIPTION
This replaces manual implementations of `Job` with a custom proc macro
attribute. This attribute goes onto a function with the appropriate
signature, and will generate the job struct, job impl, and job
registration.

If the first argument is a reference, it's assumed to be the environment
type. Taking a reference for any other reason is invalid, since the
resulting struct has to be owned. Someone attempting to use a reference
for anything other than the env will get errors about missing lifetimes,
and if they try to add them they'll get an error that we don't accept
generic functions.

We will generate a function that returns the job struct. Example usage
looks like this:

    #[swirl::background_job]
    fn do_work(env: &MyEnv, arg1: String, arg2: String) -> Result<(), swirl::PerformError> {
        // arg1 and arg2 were serialized to the database, env comes from
        // the runner
    }

    fn do_work_later(conn: &PgConnection) -> Result<(), swirl::EnqueueError> {
        do_work("a".into(), "b".into()).enqueue(conn)
    }

The vast majority of the code is validating input, since we accept a
very small subset of valid Rust functions. The only thing that we could
theoretically accept that we don't currently are arguments with any
pattern other than an identifier.

While I don't expect folks to be referencing the generated job type, the
generated type will have the path `fn_name::Job`, so it should be easy
to document and for folks to find if it's ever needed.