### PR TITLE
Add a configurable timeout for jobs starting

### DIFF
--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -12,6 +12,7 @@ lazy_static = "1.0.0"
 serde = { version = "1.0.0", features = ["derive"] }
 dotenv = "0.11"
 antidote = "1.0.0"
+assert_matches = "1.0.0"
 
 [[test]]
 name = "integration_tests"

--- a/integration_tests/tests/test_guard.rs
+++ b/integration_tests/tests/test_guard.rs
@@ -2,6 +2,7 @@ use antidote::{Mutex, MutexGuard};
 use diesel::prelude::*;
 use diesel::r2d2;
 use std::ops::{Deref, DerefMut};
+use std::time::Duration;
 use swirl::{Builder, Runner};
 
 use crate::db::*;
@@ -55,6 +56,16 @@ pub struct GuardBuilder<Env: 'static> {
 }
 
 impl<Env> GuardBuilder<Env> {
+    pub fn thread_count(mut self, count: usize) -> Self {
+        self.builder = self.builder.thread_count(count);
+        self
+    }
+
+    pub fn job_start_timeout(mut self, timeout: Duration) -> Self {
+        self.builder = self.builder.job_start_timeout(timeout);
+        self
+    }
+
     pub fn build<'a>(self) -> TestGuard<'a, Env> {
         TestGuard {
             _lock: TEST_MUTEX.lock(),


### PR DESCRIPTION
This only affects the behavior of `run_all_pending_jobs`. This should be
set to well over the maximum time a job is expected to run. The
intention here is that if an unexpected fatal error occurs (connection
pool or thread pool are corrupted, jobs are hanging forever, etc), we
return an error from `run_all_pending_jobs` so the runner can be killed
and restarted.

This doesn't currently set a timeout on getting a connection from the
pool, that depends on https://github.com/sfackler/r2d2/pull/73 and will
be explicitly tested once we're giving the pool to jobs rather than
expecting it to be in the environment (there's some trickiness in place
to make sure we still run some jobs if the connection pool size is equal
to the thread pool size and only some jobs require a database
connection)