### PR TITLE
Ensure imports used in job bodies are considered used

### DIFF
--- a/integration_tests/tests/codegen.rs
+++ b/integration_tests/tests/codegen.rs
@@ -60,3 +60,25 @@ fn env_can_have_any_name() {
     runner.run_all_pending_jobs().unwrap();
     runner.assert_no_failed_jobs().unwrap();
 }
+
+#[test]
+#[forbid(unused_imports)]
+fn test_imports_only_used_in_job_body_are_not_warned_as_unused() {
+    use std::io::prelude::*;
+
+    #[swirl::background_job]
+    fn uses_trait_import() -> Result<(), swirl::PerformError> {
+        let mut buf = Vec::new();
+        buf.write_all(b"foo")?;
+        let s = String::from_utf8(buf)?;
+        assert_eq!(s, "foo");
+        Ok(())
+    }
+
+    let runner = TestGuard::dummy_runner();
+    let conn = runner.connection_pool().get().unwrap();
+    uses_trait_import().enqueue(&conn).unwrap();
+
+    runner.run_all_pending_jobs().unwrap();
+    runner.assert_no_failed_jobs().unwrap();
+}

--- a/swirl_proc_macro/src/background_job.rs
+++ b/swirl_proc_macro/src/background_job.rs
@@ -29,6 +29,16 @@ pub fn expand(item: syn::ItemFn) -> Result<TokenStream, Diagnostic> {
             }
         }
 
+        impl swirl::Job for Job {
+            type Environment = #env_type;
+            const JOB_TYPE: &'static str = stringify!(#name);
+
+            #fn_token perform(self, #env_pat: &Self::Environment) #return_type {
+                let Job { #(#arg_names),* } = self;
+                #(#body)*
+            }
+        }
+
         mod #name {
             use super::*;
 
@@ -36,16 +46,6 @@ pub fn expand(item: syn::ItemFn) -> Result<TokenStream, Diagnostic> {
             #[serde(crate = "swirl::serde")]
             pub struct Job {
                 #(#struct_def),*
-            }
-
-            impl swirl::Job for Job {
-                type Environment = #env_type;
-                const JOB_TYPE: &'static str = stringify!(#name);
-
-                #fn_token perform(self, #env_pat: &Self::Environment) #return_type {
-                    let Job { #(#arg_names),* } = self;
-                    #(#body)*
-                }
             }
 
             swirl::register_job!(Job);


### PR DESCRIPTION
If a trait is imported, but only used in the job body (which is in its
own module and only in scope because of `use super::*;`), the compiler
warns that the import is unused. This might be a bug in the compiler,
but we can work around it by moving the generated `Job` impl out of the
generated module.

Fixes #6