### PR TITLE
Allow the environment argument to have any name

### DIFF
--- a/integration_tests/tests/codegen.rs
+++ b/integration_tests/tests/codegen.rs
@@ -43,3 +43,19 @@ fn jobs_with_args_but_no_env() {
     runner.run_all_pending_jobs().unwrap();
     runner.assert_no_failed_jobs().unwrap();
 }
+
+#[test]
+fn env_can_have_any_name() {
+    #[swirl::background_job]
+    fn env_with_different_name(environment: &String) -> Result<(), swirl::PerformError> {
+        assert_eq!(environment, "my environment");
+        Ok(())
+    }
+
+    let runner = TestGuard::runner(String::from("my environment"));
+    let conn = runner.connection_pool().get().unwrap();
+    env_with_different_name().enqueue(&conn).unwrap();
+
+    runner.run_all_pending_jobs().unwrap();
+    runner.assert_no_failed_jobs().unwrap();
+}


### PR DESCRIPTION
This was previously hard coded as `env`, which leads to extremely
confusing error messages if you tried to use another name instead.