### PR TITLE
Don't require a serde dependency in consuming crates

### DIFF
--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -9,7 +9,6 @@ autotests = false
 diesel = { version = "1.0.0", features = ["postgres", "r2d2"] }
 swirl = { path = "../swirl" }
 lazy_static = "1.0.0"
-serde = { version = "1.0.0", features = ["derive"] }
 dotenv = "0.11"
 antidote = "1.0.0"
 assert_matches = "1.0.0"

--- a/swirl/Cargo.toml
+++ b/swirl/Cargo.toml
@@ -12,6 +12,7 @@ diesel = { version = "1.0.0", features = ["postgres", "serde_json"] }
 threadpool = "1.7"
 serde_json = "1.0.0"
 serde = "1.0.0"
+serde_derive = "1.0.90"
 inventory = "0.1"
 
 [dev-dependencies]

--- a/swirl/src/lib.rs
+++ b/swirl/src/lib.rs
@@ -5,6 +5,8 @@ extern crate diesel;
 
 #[doc(hidden)]
 pub extern crate inventory;
+#[doc(hidden)]
+pub extern crate serde;
 
 mod job;
 mod registry;
@@ -16,6 +18,9 @@ pub mod db;
 pub mod schema;
 
 pub use swirl_proc_macro::*;
+
+#[doc(hidden)]
+pub use serde_derive::{Serialize, Deserialize};
 
 pub use errors::*;
 pub use job::*;

--- a/swirl_proc_macro/src/background_job.rs
+++ b/swirl_proc_macro/src/background_job.rs
@@ -31,7 +31,8 @@ pub fn expand(item: syn::ItemFn) -> Result<TokenStream, Diagnostic> {
         mod #name {
             use super::*;
 
-            #[derive(serde::Serialize, serde::Deserialize)]
+            #[derive(swirl::Serialize, swirl::Deserialize)]
+            #[serde(crate = "swirl::serde")]
             pub struct Job {
                 #(#struct_def),*
             }


### PR DESCRIPTION
Prior to serde_derive 1.0.90, there was no way for us to re-export
everything required for this derive to function without requiring that
all users of swirl have serde in their `Cargo.toml`. While it's probably
likely that anyone using this library is already using Serde, it's still
an arbitrary restriction.

Now we can re-export everything required from swirl directly. I've
specifically depended on `serde_derive` instead of `serde = { features
= ["derive"] }`, since we will only work with version 1.0.90 or later of
the derive crate, and serde does not have a strict version requirement
on the derive crate when the feature is enabled.

Fixes #9 