### PR TITLE
Revamp error handling & testing

### DIFF
--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0.0", features = ["derive"] }
 dotenv = "0.11"
 antidote = "1.0.0"
 assert_matches = "1.0.0"
+failure = { features = ["backtrace"] }
 
 [[test]]
 name = "integration_tests"

--- a/integration_tests/tests/runner.rs
+++ b/integration_tests/tests/runner.rs
@@ -1,23 +1,25 @@
 use assert_matches::assert_matches;
 use diesel::prelude::*;
+use failure::Fallible;
 use std::sync::mpsc::sync_channel;
 use std::thread;
 use std::time::Duration;
 use swirl::schema::*;
+use swirl::JobsFailed;
 
 use crate::dummy_jobs::*;
 use crate::sync::Barrier;
 use crate::test_guard::TestGuard;
 
 #[test]
-fn run_all_pending_jobs_returns_when_all_jobs_enqueued() {
+fn run_all_pending_jobs_returns_when_all_jobs_enqueued() -> Fallible<()> {
     let barrier = Barrier::new(3);
     let runner = TestGuard::runner(barrier.clone());
-    let conn = runner.connection_pool().get().unwrap();
-    barrier_job().enqueue(&conn).unwrap();
-    barrier_job().enqueue(&conn).unwrap();
+    let conn = runner.connection_pool().get()?;
+    barrier_job().enqueue(&conn)?;
+    barrier_job().enqueue(&conn)?;
 
-    runner.run_all_pending_jobs().unwrap();
+    runner.run_all_pending_jobs()?;
 
     let queued_job_count = background_jobs::table.count().get_result(&conn);
     let unlocked_job_count = background_jobs::table
@@ -31,17 +33,18 @@ fn run_all_pending_jobs_returns_when_all_jobs_enqueued() {
     assert_eq!(Ok(0), unlocked_job_count);
 
     barrier.wait();
+    Ok(())
 }
 
 #[test]
-fn assert_no_failed_jobs_blocks_until_all_queued_jobs_are_finished() {
+fn check_for_failed_jobs_blocks_until_all_queued_jobs_are_finished() -> Fallible<()> {
     let barrier = Barrier::new(3);
     let runner = TestGuard::runner(barrier.clone());
-    let conn = runner.connection_pool().get().unwrap();
-    barrier_job().enqueue(&conn).unwrap();
-    barrier_job().enqueue(&conn).unwrap();
+    let conn = runner.connection_pool().get()?;
+    barrier_job().enqueue(&conn)?;
+    barrier_job().enqueue(&conn)?;
 
-    runner.run_all_pending_jobs().unwrap();
+    runner.run_all_pending_jobs()?;
 
     let (send, recv) = sync_channel(0);
     let handle = thread::spawn(move || {
@@ -56,38 +59,39 @@ fn assert_no_failed_jobs_blocks_until_all_queued_jobs_are_finished() {
         assert!(recv.recv().is_ok(), "wait_for_jobs didn't return");
     });
 
-    runner.assert_no_failed_jobs().unwrap();
-    send.send(1).unwrap();
+    runner.check_for_failed_jobs()?;
+    send.send(1)?;
     handle.join().unwrap();
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "3 jobs failed")]
-fn assert_no_failed_jobs_panics_if_jobs_failed() {
+fn check_for_failed_jobs_panics_if_jobs_failed() -> Fallible<()> {
     let runner = TestGuard::dummy_runner();
-    let conn = runner.connection_pool().get().unwrap();
-    failure_job().enqueue(&conn).unwrap();
-    failure_job().enqueue(&conn).unwrap();
-    failure_job().enqueue(&conn).unwrap();
+    let conn = runner.connection_pool().get()?;
+    failure_job().enqueue(&conn)?;
+    failure_job().enqueue(&conn)?;
+    failure_job().enqueue(&conn)?;
 
-    runner.run_all_pending_jobs().unwrap();
-    runner.assert_no_failed_jobs().unwrap();
+    runner.run_all_pending_jobs()?;
+    assert_eq!(Err(JobsFailed(3)), runner.check_for_failed_jobs());
+    Ok(())
 }
 
 #[test]
-#[should_panic(expected = "2 jobs failed")]
-fn panicking_jobs_are_caught_and_treated_as_failures() {
+fn panicking_jobs_are_caught_and_treated_as_failures() -> Fallible<()> {
     let runner = TestGuard::dummy_runner();
-    let conn = runner.connection_pool().get().unwrap();
-    panic_job().enqueue(&conn).unwrap();
-    failure_job().enqueue(&conn).unwrap();
+    let conn = runner.connection_pool().get()?;
+    panic_job().enqueue(&conn)?;
+    failure_job().enqueue(&conn)?;
 
-    runner.run_all_pending_jobs().unwrap();
-    runner.assert_no_failed_jobs().unwrap();
+    runner.run_all_pending_jobs()?;
+    assert_eq!(Err(JobsFailed(2)), runner.check_for_failed_jobs());
+    Ok(())
 }
 
 #[test]
-fn run_all_pending_jobs_errs_if_jobs_dont_start_in_timeout() {
+fn run_all_pending_jobs_errs_if_jobs_dont_start_in_timeout() -> Fallible<()> {
     let barrier = Barrier::new(2);
     // A runner with 1 thread where all jobs will hang indefinitely.
     // The second job will never start.
@@ -95,9 +99,9 @@ fn run_all_pending_jobs_errs_if_jobs_dont_start_in_timeout() {
         .thread_count(1)
         .job_start_timeout(Duration::from_millis(50))
         .build();
-    let conn = runner.connection_pool().get().unwrap();
-    barrier_job().enqueue(&conn).unwrap();
-    barrier_job().enqueue(&conn).unwrap();
+    let conn = runner.connection_pool().get()?;
+    barrier_job().enqueue(&conn)?;
+    barrier_job().enqueue(&conn)?;
 
     let run_result = runner.run_all_pending_jobs();
     assert_matches!(run_result, Err(swirl::FetchError::NoMessageReceived));
@@ -105,5 +109,6 @@ fn run_all_pending_jobs_errs_if_jobs_dont_start_in_timeout() {
     // Make sure the jobs actually run so we don't panic on drop
     barrier.wait();
     barrier.wait();
-    runner.assert_no_failed_jobs().unwrap();
+    runner.check_for_failed_jobs()?;
+    Ok(())
 }

--- a/swirl/examples/run_100k_jobs.rs
+++ b/swirl/examples/run_100k_jobs.rs
@@ -23,7 +23,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let started = Instant::now();
 
     runner.run_all_pending_jobs()?;
-    runner.assert_no_failed_jobs()?;
+    runner.check_for_failed_jobs()?;
 
     let elapsed = started.elapsed();
     println!("Ran 100k jobs in {} seconds", elapsed.as_secs());

--- a/swirl/src/db.rs
+++ b/swirl/src/db.rs
@@ -21,7 +21,7 @@ pub trait BorrowedConnection<'a> {
 pub trait DieselPool: Clone + Send + for<'a> BorrowedConnection<'a> {
     /// The error type returned when a connection could not be retreived from
     /// the pool.
-    type Error: Error + Send + 'static;
+    type Error: Error + Send + Sync + 'static;
 
     /// Attempt to get a database connection from the pool. Errors if a
     /// connection could not be retrieved from the pool.

--- a/swirl/src/lib.rs
+++ b/swirl/src/lib.rs
@@ -11,8 +11,8 @@ mod registry;
 mod runner;
 mod storage;
 
-pub mod errors;
 pub mod db;
+pub mod errors;
 pub mod schema;
 
 pub use swirl_proc_macro::*;

--- a/swirl/src/runner.rs
+++ b/swirl/src/runner.rs
@@ -196,20 +196,37 @@ where
         })
     }
 
-    fn connection(&self) -> Result<DieselPooledConn<ConnectionPool>, Box<dyn Error>> {
+    fn connection(&self) -> Result<DieselPooledConn<ConnectionPool>, Box<dyn Error + Send + Sync>> {
         self.connection_pool.get().map_err(Into::into)
     }
 
-    pub fn assert_no_failed_jobs(&self) -> Result<(), Box<dyn Error>> {
-        self.wait_for_jobs();
+    /// Waits for all running jobs to complete, and returns an error if any
+    /// failed
+    ///
+    /// This function is intended for use in tests. If any jobs have failed, it
+    /// will return `swirl::JobsFailed` with the number of jobs that failed.
+    ///
+    /// If any other unexpected errors occurred, such as panicked worker threads
+    /// or an error loading the job count from the database, an opaque error
+    /// will be returned.
+    pub fn check_for_failed_jobs(&self) -> Result<(), FailedJobsError> {
+        self.wait_for_jobs()?;
         let failed_jobs = storage::failed_job_count(&*self.connection()?)?;
-        assert_eq!(0, failed_jobs, "{} jobs failed", failed_jobs);
-        Ok(())
+        if failed_jobs == 0 {
+            Ok(())
+        } else {
+            Err(JobsFailed(failed_jobs))
+        }
     }
 
-    fn wait_for_jobs(&self) {
+    fn wait_for_jobs(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
         self.thread_pool.join();
-        assert_eq!(0, self.thread_pool.panic_count());
+        let panic_count = self.thread_pool.panic_count();
+        if panic_count == 0 {
+            Ok(())
+        } else {
+            Err(format!("{} threads panicked", panic_count).into())
+        }
     }
 }
 
@@ -267,7 +284,7 @@ mod tests {
             Ok(())
         });
 
-        runner.wait_for_jobs();
+        runner.wait_for_jobs().unwrap();
     }
 
     #[test]
@@ -278,7 +295,7 @@ mod tests {
         create_dummy_job(&runner);
 
         runner.get_single_job(channel::dummy_sender(), |_| Ok(()));
-        runner.wait_for_jobs();
+        runner.wait_for_jobs().unwrap();
 
         let remaining_jobs = background_jobs
             .count()
@@ -325,7 +342,7 @@ mod tests {
             .unwrap();
         assert_eq!(1, total_jobs_including_failed.len());
 
-        runner.wait_for_jobs();
+        runner.wait_for_jobs().unwrap();
     }
 
     #[test]
@@ -335,7 +352,7 @@ mod tests {
         let job_id = create_dummy_job(&runner).id;
 
         runner.get_single_job(channel::dummy_sender(), |_| panic!());
-        runner.wait_for_jobs();
+        runner.wait_for_jobs().unwrap();
 
         let tries = background_jobs
             .find(job_id)


### PR DESCRIPTION
This removes all uses of `dyn Error` from the public API, replacing them
with concrete types, which eases use of this library in applciations
which have their own error types (whether it's still just `Box<dyn
Error>`, `failure`, or some application specific type). The reason the
use of `Box<dyn Error>` caused pain is that `Box<dyn Error>` doesn't
implement `Error`, so `?` just doesn't work, you have to manually
convert the error to your application specific error type.

The only remaining error type in the public API is `PerformError`, which
is never returned to users, only handled by us internally. `Box<dyn
Error>` is the most flexible type we can let users return, other than
putting an associated type on `Job` (which would cause issues for
codegen)

To test that everything integrates nicely, I've changed all the
integration tests to stop using `unwrap`, and instead return errors.
I've included `failure` in the tests so that we are still able to get
backtraces like we would with `unwrap` or `panic!`. The unit tests
haven't been converted, since they still interact with non-public
methods which return `Box<dyn Error>`, which makes returning
`failure::Error` painful.

Because `#[should_panic]` isn't an option with this form of testing,
I've removed `assert_no_failed_jobs` with a new method
`check_for_failed_jobs`, which returns an error if any jobs failed.