### PR TITLE
Don't panic when a job fails to load

### DIFF
--- a/integration_tests/tests/db.rs
+++ b/integration_tests/tests/db.rs
@@ -3,9 +3,9 @@ use diesel::r2d2;
 
 pub type DieselPool = r2d2::Pool<r2d2::ConnectionManager<PgConnection>>;
 
-pub fn pool_builder() -> r2d2::Builder<r2d2::ConnectionManager<PgConnection>> {
+pub fn pool_builder(max_size: u32) -> r2d2::Builder<r2d2::ConnectionManager<PgConnection>> {
     r2d2::Pool::builder()
-        .max_size(4)
+        .max_size(max_size)
         .min_idle(Some(0))
         .connection_customizer(Box::new(SetStatementTimeout(1000)))
 }

--- a/integration_tests/tests/test_guard.rs
+++ b/integration_tests/tests/test_guard.rs
@@ -25,12 +25,14 @@ pub struct TestGuard<'a, Env: 'static> {
 
 impl<'a, Env> TestGuard<'a, Env> {
     pub fn builder(env: Env) -> GuardBuilder<Env> {
-        use dotenv;
+        Self::with_db_pool_size(env, 4)
+    }
 
+    pub fn with_db_pool_size(env: Env, pool_size: u32) -> GuardBuilder<Env> {
         let database_url =
             dotenv::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL must be set to run tests");
         let manager = r2d2::ConnectionManager::new(database_url);
-        let pool = pool_builder().build_unchecked(manager);
+        let pool = pool_builder(pool_size).build_unchecked(manager);
 
         let builder = Runner::builder(pool, env);
 

--- a/swirl/src/lib.rs
+++ b/swirl/src/lib.rs
@@ -11,8 +11,8 @@ mod registry;
 mod runner;
 mod storage;
 
-pub mod errors;
 pub mod db;
+pub mod errors;
 pub mod schema;
 
 pub use swirl_proc_macro::*;


### PR DESCRIPTION
This came up during use on crates.io. Right the only time we explicitly
panic a worker thread is when the transaction returns an error, which
happens if a job failed to load or if the update/delete after attempting
to run a job failed to execute.

Notably the job failing to load case can happen if the database is
read-only, which is something that crates.io has tests for. If the job
failed to load, we already informed the consumer since
`run_all_pending_jobs` will have returned an error. If we then proceed
to also panic the thread, `assert_no_failed_jobs` will fail, even if
there are no jobs in the DB to actually run.

I'm torn on whether we should panic or not in the case of a job failing
to update/delete. I've left it as a panic for now, since I think we
probably still want `assert_no_failed_jobs` to fail in this case, but we
should never be able to lock a job and fail to update/delete it unless
the database went down while the job was running, so it should never
really affect tests. In production as long as it shows up in logs we
don't really care. I'll probably change this to not panic when we add
more proper logging.

Fixes #7
Fixes #8