### PR TITLE
Integrate connection pool configuration into the runner

### DIFF
--- a/integration_tests/tests/db.rs
+++ b/integration_tests/tests/db.rs
@@ -2,10 +2,10 @@ use diesel::prelude::*;
 use diesel::r2d2;
 
 pub type DieselPool = r2d2::Pool<r2d2::ConnectionManager<PgConnection>>;
+pub type PoolBuilder = r2d2::Builder<r2d2::ConnectionManager<PgConnection>>;
 
-pub fn pool_builder(max_size: u32) -> r2d2::Builder<r2d2::ConnectionManager<PgConnection>> {
+pub fn pool_builder() -> PoolBuilder {
     r2d2::Pool::builder()
-        .max_size(max_size)
         .min_idle(Some(0))
         .connection_customizer(Box::new(SetStatementTimeout(1000)))
 }

--- a/integration_tests/tests/runner.rs
+++ b/integration_tests/tests/runner.rs
@@ -115,7 +115,10 @@ fn run_all_pending_jobs_errs_if_jobs_dont_start_in_timeout() -> Fallible<()> {
 
 #[test]
 fn jobs_failing_to_load_doesnt_panic_threads() -> Fallible<()> {
-    let runner = TestGuard::with_db_pool_size((), 1).thread_count(1).build();
+    let runner = TestGuard::builder(())
+        .thread_count(1)
+        .connection_count(1)
+        .build();
 
     {
         let conn = runner.connection_pool().get()?;


### PR DESCRIPTION
This moves the responsibility of constructing the database connection
pool into the runner's builder. This lets us reduce the amount of
boilerplate when no configuration is needed, and provide a reasonable
default pool size of 2 * the thread pool size (meaning if every job
requires a database connection, we can still utilize every thread).

With this change, there is no public API which gives a reference to the
runner's connection pool. The main reason to do this would be to put the
same pool on the job environment. The plan is to allow jobs to take a
connection as an argument to support this use case. This will be done in
a separate commit.