### PR TITLE
Allow background jobs to take connections as an argument

### DIFF
--- a/swirl/src/job.rs
+++ b/swirl/src/job.rs
@@ -1,6 +1,7 @@
 use diesel::PgConnection;
 use serde::{de::DeserializeOwned, Serialize};
 
+use crate::db::DieselPoolObj;
 use crate::errors::{EnqueueError, PerformError};
 use crate::storage;
 
@@ -22,5 +23,6 @@ pub trait Job: Serialize + DeserializeOwned {
     }
 
     /// The logic involved in actually performing this job.
-    fn perform(self, env: &Self::Environment) -> Result<(), PerformError>;
+    fn perform(self, env: &Self::Environment, pool: &dyn DieselPoolObj)
+        -> Result<(), PerformError>;
 }

--- a/swirl_proc_macro/src/diagnostic_shim.rs
+++ b/swirl_proc_macro/src/diagnostic_shim.rs
@@ -35,6 +35,11 @@ impl Diagnostic {
             message: msg.into(),
         }
     }
+
+    pub(crate) fn help<T: Into<String>>(mut self, msg: T) -> Self {
+        self.message += &format!("\nhelp: {}", msg.into());
+        self
+    }
 }
 
 pub trait DiagnosticExt {


### PR DESCRIPTION
This improves the ergonomics of using swirl when your background jobs
require a database connection. Prior to this commit, users would have to
keep a connection pool (ideally the same one used by the runner) on
their environment struct and manually grab a connection of of it. This
commit changes that behavior so jobs can take either a connection or a
pool as an argument, and swirl will automatically pass it in.

The first piece of this change is adjusting the `Job` trait to be able
to take a connection in the first place. We need `Job` to be object
safe, and `DieselPool` isn't. This leaves us with two options. One would
be to just pass `&PgConnection` to `perform`. This would mean we pull a
connection out of the pool even if the job doesn't need it, which seems
suboptimal. We could have separate `perform` and
`perform_with_connection` functions, relying on the runner to call the
right one, but that means that some impls of `Job` would always fail if
you called the wrong function, and we still wouldn't be able to support
jobs which need more than one connection (which is perhaps fine, that's
a niche use case and folks can just stick their own connection pool on
the environment if they need it)

So what we've done is introduced an object safe version of `DieselPool`.
This means that we need to heap allocation the connections when we pull
them out, which sucks. I've added another function that takes a closure
to avoid the allocation for jobs which only need a single connection.
I'm not super excited about the name `DieselPoolObj`, but we can always
change it later. I'm not even sure I want to support taking a connection
pool in the public API, but it was easy enough to implement.

At the moment the DB arg has to have the type `&PgConnection` or
`&DieselPoolObj`. Type aliases can't be used.

The second change is the codegen required to actually use this
connection. I've changed the argument parsing rules to be a little
looser. When we come across a reference, we see if it's to a connection
or pool, and if so we assume it's the db arg -- otherwise we assume it's
the env. If we try to set the db or env arg twice, we'll error. This
means that they can technically appear in any order, which is perhaps a
bit confusing, but I think it's not worth the complexity to assert that
they're the first two arguments.

One future extension which might be nice is to add attributes that folks
can put on either argument to force us to treat any argument as the DB
conn or environment, which can reduce confusion and would allow type
aliases to be used if needed.