### PR TITLE
Re-enable injecting a fully constructed connection pool

### DIFF
--- a/integration_tests/tests/db.rs
+++ b/integration_tests/tests/db.rs
@@ -2,9 +2,9 @@ use diesel::prelude::*;
 use diesel::r2d2;
 
 pub type DieselPool = r2d2::Pool<r2d2::ConnectionManager<PgConnection>>;
-pub type PoolBuilder = r2d2::Builder<r2d2::ConnectionManager<PgConnection>>;
+pub type PoolBuilder = swirl::db::R2d2Builder;
 
-pub fn pool_builder() -> PoolBuilder {
+pub fn pool_builder() -> r2d2::Builder<r2d2::ConnectionManager<PgConnection>> {
     r2d2::Pool::builder()
         .min_idle(Some(0))
         .connection_customizer(Box::new(SetStatementTimeout(1000)))

--- a/integration_tests/tests/test_guard.rs
+++ b/integration_tests/tests/test_guard.rs
@@ -26,7 +26,7 @@ impl<'a, Env> TestGuard<'a, Env> {
     pub fn builder(env: Env) -> GuardBuilder<Env> {
         let database_url =
             dotenv::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL must be set to run tests");
-        let builder = Runner::builder(database_url, env).connection_pool_builder(pool_builder());
+        let builder = Runner::builder(env).connection_pool_builder(database_url, pool_builder());
 
         GuardBuilder { builder }
     }

--- a/swirl/examples/run_100k_jobs.rs
+++ b/swirl/examples/run_100k_jobs.rs
@@ -11,7 +11,7 @@ fn dummy_job() -> Result<(), PerformError> {
 fn main() -> Result<(), Box<dyn Error>> {
     let database_url = dotenv::var("DATABASE_URL")?;
     println!("Enqueuing 100k jobs");
-    let runner = Runner::builder(database_url, ()).build();
+    let runner = Runner::builder(()).database_url(database_url).build();
     enqueue_jobs(&*runner.connection_pool().get()?).unwrap();
     println!("Running jobs");
     let started = Instant::now();


### PR DESCRIPTION
crates.io needs this behavior in tests, where we want to make sure that
everything uses the same single connection which is inside a
transaction.

This commit brings back the ability to provide your own pool, which was
removed in #18. To accomplish this we had to move some things around in
funky ways. The end result is that the ability to give a DB url or a
partially configured pool is now only available for r2d2. To use
another pool, you just need to pass it in manually.