### PR TITLE
Run jobs that take no environment from any runner

### DIFF
--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -12,7 +12,7 @@ lazy_static = "1.0.0"
 dotenv = "0.11"
 antidote = "1.0.0"
 assert_matches = "1.0.0"
-failure = { features = ["backtrace"] }
+failure = { version = "*", features = ["backtrace"] }
 
 [[test]]
 name = "integration_tests"

--- a/swirl_proc_macro/src/background_job.rs
+++ b/swirl_proc_macro/src/background_job.rs
@@ -108,9 +108,10 @@ impl BackgroundJob {
         }
 
         if let Some(where_clause) = sig.generics.where_clause {
-            return Err(where_clause.where_token.span.error(
-                "#[swirl::background_job] cannot be used on functions with a where clause",
-            ));
+            return Err(where_clause
+                .where_token
+                .span
+                .error("#[swirl::background_job] cannot be used on functions with a where clause"));
         }
 
         let fn_token = sig.fn_token;


### PR DESCRIPTION
Attempting to update crates.io to the most recent version of swirl
caused jobs to fail to run. The cause of this was that one of our jobs
only needed a DB connection, not the environment. This caused the job's
environment type to be `()`, meaning our runner would not find it in the
registry (since the environment type didn't match).

The fix on the crates.io side would be to add an unused argument with
the environment, but this feels like such a major pitfall that I want to
avoid it in Swirl. Having a few jobs that need a shared environment, and
many that only need a database connection (or neither) seems common
enough to warrant special casing jobs with no environment.

This was relatively easy to track down on the crates.io side since the
jobs were failing to run (and thus logging their failure). However, this
does beg the question of whether having jobs with different environments
in the same database is going to be a use case we need to support, in
which case we probably want the runner to ignore job types it doesn't
know about.